### PR TITLE
Fix cache key and return value on first call

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -1,16 +1,19 @@
 const hash = require('object-hash');
 
+const toSafeObject = obj => JSON.parse(JSON.stringify(obj || {}));
+
 function cache(func, options) {
   return (root, args, context) => {
     if (!context.resolverCache) {
       throw new Error('Missing resolverCache property on the Graphql context.');
     }
 
-    const key = `${hash(root)}:${hash(args)}`;
+    const key = `${hash(func)}:${hash(toSafeObject(root))}:${hash(toSafeObject(args))}`;
     const executeAndCache = () =>
-      Promise.resolve(func(root, args, context)).then(value =>
-        context.resolverCache.set(key, value, options)
-      );
+      Promise.resolve(func(root, args, context)).then((value) => {
+        context.resolverCache.set(key, value, options);
+        return value;
+      });
 
     return (
       context.resolverCache


### PR DESCRIPTION
If a top level query is cached, `root` would be null and the cache key is ambiguously. That's why I've added `hash(func)` to the cache key.
Additionally if `root` or `args` including non plain objects, it's possible that `object-hash` fail.
